### PR TITLE
Fix entry and restore input page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kokorokagami-new",
-  "main": "expo-router/entry",
+  "main": "index.js",
   "version": "1.0.0",
   "scripts": {
     "start": "expo start",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import {SafeAreaView, StyleSheet} from 'react-native';
+import { SafeAreaView, StyleSheet } from 'react-native';
 import UserInputScreen from './screens/UserInputScreen';
-
 
 const App = () => {
   return (
@@ -12,7 +11,9 @@ const App = () => {
 };
 
 const styles = StyleSheet.create({
-  container: {flex: 1, justifyContent: 'center', alignItems: 'center'},
+  container: {
+    flex: 1,
+  },
 });
 
 export default App;

--- a/src/screens/UserInputScreen.tsx
+++ b/src/screens/UserInputScreen.tsx
@@ -49,6 +49,7 @@ const UserInputScreen = () => {
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       style={{flex: 1}}>
       <ScrollView contentContainerStyle={styles.container}>
+        <Text style={styles.title}>Welcome to ココロ鏡</Text>
         <Text style={styles.label}>名前</Text>
         <TextInput
           placeholder="例：花子"
@@ -159,6 +160,12 @@ const styles = StyleSheet.create({
   container: {
     padding: 20,
     backgroundColor: '#FFF6F6',
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 16,
+    color: '#8B7FD9',
+    textAlign: 'center',
   },
   label: {
     marginTop: 10,


### PR DESCRIPTION
## Summary
- point Expo entry to `index.js`
- restore and polish `UserInputScreen`
- render the input screen from `App`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851553f69ec83209da9bbf907842ebc