### PR TITLE
Add navigation skeleton with placeholder screens

### DIFF
--- a/components/__tests__/__snapshots__/StyledText-test.js.snap
+++ b/components/__tests__/__snapshots__/StyledText-test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `null`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,162 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import WelcomeScreen from './screens/WelcomeScreen';
 import LoginScreen from './screens/LoginScreen';
 import UserInputScreen from './screens/UserInputScreen';
 import HomeScreen from './screens/HomeScreen';
+import SplashScreen from './screens/Auth/SplashScreen';
+import SMSVerifyScreen from './screens/Auth/SMSVerifyScreen';
+import PrivacyPolicyScreen from './screens/Auth/PrivacyPolicyScreen';
+import DivinationScreen from './screens/Home/DivinationScreen';
+import MyPageScreen from './screens/Home/MyPageScreen';
+import HoroscopeHome from './screens/Horoscope/HoroscopeHome';
+import HoroscopeResult from './screens/Horoscope/HoroscopeResult';
+import HoroscopeDetail from './screens/Horoscope/HoroscopeDetail';
+import NatalChartInput from './screens/NatalChart/NatalChartInput';
+import NatalChartGraph from './screens/NatalChart/NatalChartGraph';
+import NatalChartAnalysis from './screens/NatalChart/NatalChartAnalysis';
+import NatalChartElementDetail from './screens/NatalChart/NatalChartElementDetail';
+import BaziInput from './screens/Bazi/BaziInput';
+import BaziBasicAnalysis from './screens/Bazi/BaziBasicAnalysis';
+import BaziDetailAnalysis from './screens/Bazi/BaziDetailAnalysis';
+import BaziLuckFlow from './screens/Bazi/BaziLuckFlow';
+import TarotSelect from './screens/Tarot/TarotSelect';
+import TarotDraw from './screens/Tarot/TarotDraw';
+import TarotCardMean from './screens/Tarot/TarotCardMean';
+import TarotResult from './screens/Tarot/TarotResult';
+import MatchPartnerInput from './screens/Match/MatchPartnerInput';
+import MatchCalculation from './screens/Match/MatchCalculation';
+import MatchResult from './screens/Match/MatchResult';
+import MatchDetail from './screens/Match/MatchDetail';
+import FriendList from './screens/Social/FriendList';
+import MatchRanking from './screens/Social/MatchRanking';
+import ShareCard from './screens/Social/ShareCard';
+import Community from './screens/Social/Community';
+import ChatList from './screens/ChatAI/ChatList';
+import ChatScreen from './screens/ChatAI/ChatScreen';
+import ChatTopicSuggest from './screens/ChatAI/ChatTopicSuggest';
+import ChatHistory from './screens/ChatAI/ChatHistory';
+import UserProfile from './screens/Profile/UserProfile';
+import MyReports from './screens/Profile/MyReports';
+import Favorites from './screens/Profile/Favorites';
+import Settings from './screens/Profile/Settings';
+import NotificationSettings from './screens/Profile/NotificationSettings';
+import HelpCenter from './screens/Profile/HelpCenter';
+import AboutUs from './screens/Profile/AboutUs';
+import Feedback from './screens/Profile/Feedback';
+import VIPCenter from './screens/Commerce/VIPCenter';
+import SubscribePlan from './screens/Commerce/SubscribePlan';
+import PaymentScreen from './screens/Commerce/PaymentScreen';
+import PointShop from './screens/Commerce/PointShop';
+import PurchaseHistory from './screens/Commerce/PurchaseHistory';
+import InviteFriend from './screens/Commerce/InviteFriend';
+import DailyCheckIn from './screens/Operation/DailyCheckIn';
+import EventCenter from './screens/Operation/EventCenter';
+import Announcements from './screens/Operation/Announcements';
+import OnboardingGuide from './screens/Operation/OnboardingGuide';
+import VersionUpdate from './screens/Operation/VersionUpdate';
+import SeasonalTheme from './screens/Operation/SeasonalTheme';
 
 const Stack = createNativeStackNavigator();
+const Tab = createBottomTabNavigator();
+const HomeStack = createNativeStackNavigator();
+const DivStack = createNativeStackNavigator();
+const ProfileStack = createNativeStackNavigator();
+
+function HomeStackScreen() {
+  return (
+    <HomeStack.Navigator screenOptions={{ headerShown: false }}>
+      <HomeStack.Screen name="Home" component={HomeScreen} />
+    </HomeStack.Navigator>
+  );
+}
+
+function DivinationStackScreen() {
+  return (
+    <DivStack.Navigator screenOptions={{ headerShown: false }}>
+      <DivStack.Screen name="Divination" component={DivinationScreen} />
+      <DivStack.Screen name="HoroscopeHome" component={HoroscopeHome} />
+      <DivStack.Screen name="HoroscopeResult" component={HoroscopeResult} />
+      <DivStack.Screen name="HoroscopeDetail" component={HoroscopeDetail} />
+      <DivStack.Screen name="NatalChartInput" component={NatalChartInput} />
+      <DivStack.Screen name="NatalChartGraph" component={NatalChartGraph} />
+      <DivStack.Screen name="NatalChartAnalysis" component={NatalChartAnalysis} />
+      <DivStack.Screen name="NatalChartElementDetail" component={NatalChartElementDetail} />
+      <DivStack.Screen name="BaziInput" component={BaziInput} />
+      <DivStack.Screen name="BaziBasicAnalysis" component={BaziBasicAnalysis} />
+      <DivStack.Screen name="BaziDetailAnalysis" component={BaziDetailAnalysis} />
+      <DivStack.Screen name="BaziLuckFlow" component={BaziLuckFlow} />
+      <DivStack.Screen name="TarotSelect" component={TarotSelect} />
+      <DivStack.Screen name="TarotDraw" component={TarotDraw} />
+      <DivStack.Screen name="TarotCardMean" component={TarotCardMean} />
+      <DivStack.Screen name="TarotResult" component={TarotResult} />
+      <DivStack.Screen name="MatchPartnerInput" component={MatchPartnerInput} />
+      <DivStack.Screen name="MatchCalculation" component={MatchCalculation} />
+      <DivStack.Screen name="MatchResult" component={MatchResult} />
+      <DivStack.Screen name="MatchDetail" component={MatchDetail} />
+      <DivStack.Screen name="FriendList" component={FriendList} />
+      <DivStack.Screen name="MatchRanking" component={MatchRanking} />
+      <DivStack.Screen name="ShareCard" component={ShareCard} />
+      <DivStack.Screen name="Community" component={Community} />
+      <DivStack.Screen name="ChatList" component={ChatList} />
+      <DivStack.Screen name="ChatScreen" component={ChatScreen} />
+      <DivStack.Screen name="ChatTopicSuggest" component={ChatTopicSuggest} />
+      <DivStack.Screen name="ChatHistory" component={ChatHistory} />
+      <DivStack.Screen name="DailyCheckIn" component={DailyCheckIn} />
+      <DivStack.Screen name="EventCenter" component={EventCenter} />
+      <DivStack.Screen name="Announcements" component={Announcements} />
+      <DivStack.Screen name="OnboardingGuide" component={OnboardingGuide} />
+      <DivStack.Screen name="VersionUpdate" component={VersionUpdate} />
+      <DivStack.Screen name="SeasonalTheme" component={SeasonalTheme} />
+    </DivStack.Navigator>
+  );
+}
+
+function ProfileStackScreen() {
+  return (
+    <ProfileStack.Navigator screenOptions={{ headerShown: false }}>
+      <ProfileStack.Screen name="MyPage" component={MyPageScreen} />
+      <ProfileStack.Screen name="UserProfile" component={UserProfile} />
+      <ProfileStack.Screen name="MyReports" component={MyReports} />
+      <ProfileStack.Screen name="Favorites" component={Favorites} />
+      <ProfileStack.Screen name="Settings" component={Settings} />
+      <ProfileStack.Screen name="NotificationSettings" component={NotificationSettings} />
+      <ProfileStack.Screen name="HelpCenter" component={HelpCenter} />
+      <ProfileStack.Screen name="AboutUs" component={AboutUs} />
+      <ProfileStack.Screen name="Feedback" component={Feedback} />
+      <ProfileStack.Screen name="VIPCenter" component={VIPCenter} />
+      <ProfileStack.Screen name="SubscribePlan" component={SubscribePlan} />
+      <ProfileStack.Screen name="PaymentScreen" component={PaymentScreen} />
+      <ProfileStack.Screen name="PointShop" component={PointShop} />
+      <ProfileStack.Screen name="PurchaseHistory" component={PurchaseHistory} />
+      <ProfileStack.Screen name="InviteFriend" component={InviteFriend} />
+    </ProfileStack.Navigator>
+  );
+}
+
+function HomeTabs() {
+  return (
+    <Tab.Navigator screenOptions={{ headerShown: false }}>
+      <Tab.Screen name="HomeTab" component={HomeStackScreen} options={{ title: 'ホーム' }} />
+      <Tab.Screen name="DivinationTab" component={DivinationStackScreen} options={{ title: '占い' }} />
+      <Tab.Screen name="ProfileTab" component={ProfileStackScreen} options={{ title: 'マイページ' }} />
+    </Tab.Navigator>
+  );
+}
 
 function App() {
   return (
     <NavigationContainer>
-      <Stack.Navigator 
-        initialRouteName="Welcome"
-        screenOptions={{ headerShown: false }}
-      >
+      <Stack.Navigator initialRouteName="Splash" screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="Splash" component={SplashScreen} />
         <Stack.Screen name="Welcome" component={WelcomeScreen} />
         <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen name="SMSVerify" component={SMSVerifyScreen} />
+        <Stack.Screen name="PrivacyPolicy" component={PrivacyPolicyScreen} />
         <Stack.Screen name="UserInput" component={UserInputScreen} />
-        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="HomeTabs" component={HomeTabs} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/screens/Auth/PrivacyPolicyScreen.tsx
+++ b/src/screens/Auth/PrivacyPolicyScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function PrivacyPolicyScreen({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはプライバシーポリシー画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Auth/SMSVerifyScreen.tsx
+++ b/src/screens/Auth/SMSVerifyScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function SMSVerifyScreen({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは認証コード入力画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Auth/SplashScreen.tsx
+++ b/src/screens/Auth/SplashScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function SplashScreen({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはスプラッシュ画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Bazi/BaziBasicAnalysis.tsx
+++ b/src/screens/Bazi/BaziBasicAnalysis.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function BaziBasicAnalysis({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは基本分析画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Bazi/BaziDetailAnalysis.tsx
+++ b/src/screens/Bazi/BaziDetailAnalysis.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function BaziDetailAnalysis({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは性格運勢画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Bazi/BaziInput.tsx
+++ b/src/screens/Bazi/BaziInput.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function BaziInput({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは四柱八字入力画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Bazi/BaziLuckFlow.tsx
+++ b/src/screens/Bazi/BaziLuckFlow.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function BaziLuckFlow({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは大運流年画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/ChatAI/ChatHistory.tsx
+++ b/src/screens/ChatAI/ChatHistory.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function ChatHistory({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはチャット履歴画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/ChatAI/ChatList.tsx
+++ b/src/screens/ChatAI/ChatList.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function ChatList({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはAIキャラ選択画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/ChatAI/ChatScreen.tsx
+++ b/src/screens/ChatAI/ChatScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function ChatScreen({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはチャット画面画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/ChatAI/ChatTopicSuggest.tsx
+++ b/src/screens/ChatAI/ChatTopicSuggest.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function ChatTopicSuggest({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは話題テンプレート画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Commerce/InviteFriend.tsx
+++ b/src/screens/Commerce/InviteFriend.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function InviteFriend({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは招待特典画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Commerce/PaymentScreen.tsx
+++ b/src/screens/Commerce/PaymentScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function PaymentScreen({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはお支払い画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Commerce/PointShop.tsx
+++ b/src/screens/Commerce/PointShop.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function PointShop({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはポイントショップ画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Commerce/PurchaseHistory.tsx
+++ b/src/screens/Commerce/PurchaseHistory.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function PurchaseHistory({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは購入履歴画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Commerce/SubscribePlan.tsx
+++ b/src/screens/Commerce/SubscribePlan.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function SubscribePlan({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはプラン選択画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Commerce/VIPCenter.tsx
+++ b/src/screens/Commerce/VIPCenter.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function VIPCenter({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはVIPセンター画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Home/DivinationScreen.tsx
+++ b/src/screens/Home/DivinationScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function DivinationScreen({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは占い機能一覧画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Home/MyPageScreen.tsx
+++ b/src/screens/Home/MyPageScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function MyPageScreen({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはマイページ画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Horoscope/HoroscopeDetail.tsx
+++ b/src/screens/Horoscope/HoroscopeDetail.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function HoroscopeDetail({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは星座詳細ページ画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Horoscope/HoroscopeHome.tsx
+++ b/src/screens/Horoscope/HoroscopeHome.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function HoroscopeHome({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは星座占いトップ画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Horoscope/HoroscopeResult.tsx
+++ b/src/screens/Horoscope/HoroscopeResult.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function HoroscopeResult({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは星座運勢結果画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Match/MatchCalculation.tsx
+++ b/src/screens/Match/MatchCalculation.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function MatchCalculation({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは計算画面画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Match/MatchDetail.tsx
+++ b/src/screens/Match/MatchDetail.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function MatchDetail({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは詳細分析画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Match/MatchPartnerInput.tsx
+++ b/src/screens/Match/MatchPartnerInput.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function MatchPartnerInput({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは相性対象入力画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Match/MatchResult.tsx
+++ b/src/screens/Match/MatchResult.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function MatchResult({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは結果表示画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/NatalChart/NatalChartAnalysis.tsx
+++ b/src/screens/NatalChart/NatalChartAnalysis.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function NatalChartAnalysis({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは解読結果画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/NatalChart/NatalChartElementDetail.tsx
+++ b/src/screens/NatalChart/NatalChartElementDetail.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function NatalChartElementDetail({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは要素詳細画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/NatalChart/NatalChartGraph.tsx
+++ b/src/screens/NatalChart/NatalChartGraph.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function NatalChartGraph({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは星図表示画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/NatalChart/NatalChartInput.tsx
+++ b/src/screens/NatalChart/NatalChartInput.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function NatalChartInput({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはホロスコープ生成画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Operation/Announcements.tsx
+++ b/src/screens/Operation/Announcements.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function Announcements({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはお知らせ画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Operation/DailyCheckIn.tsx
+++ b/src/screens/Operation/DailyCheckIn.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function DailyCheckIn({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはデイリー報酬画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Operation/EventCenter.tsx
+++ b/src/screens/Operation/EventCenter.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function EventCenter({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはイベント一覧画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Operation/OnboardingGuide.tsx
+++ b/src/screens/Operation/OnboardingGuide.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function OnboardingGuide({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは初心者ガイド画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Operation/SeasonalTheme.tsx
+++ b/src/screens/Operation/SeasonalTheme.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function SeasonalTheme({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは季節イベント占い画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Operation/VersionUpdate.tsx
+++ b/src/screens/Operation/VersionUpdate.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function VersionUpdate({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはバージョン情報画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Profile/AboutUs.tsx
+++ b/src/screens/Profile/AboutUs.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function AboutUs({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはアプリ紹介画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Profile/Favorites.tsx
+++ b/src/screens/Profile/Favorites.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function Favorites({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはお気に入り画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Profile/Feedback.tsx
+++ b/src/screens/Profile/Feedback.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function Feedback({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはフィードバック画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Profile/HelpCenter.tsx
+++ b/src/screens/Profile/HelpCenter.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function HelpCenter({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはヘルプセンター画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Profile/MyReports.tsx
+++ b/src/screens/Profile/MyReports.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function MyReports({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは占い履歴画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Profile/NotificationSettings.tsx
+++ b/src/screens/Profile/NotificationSettings.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function NotificationSettings({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは通知設定画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Profile/Settings.tsx
+++ b/src/screens/Profile/Settings.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function Settings({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはアプリ設定画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Profile/UserProfile.tsx
+++ b/src/screens/Profile/UserProfile.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function UserProfile({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはプロフィール編集画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Social/Community.tsx
+++ b/src/screens/Social/Community.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function Community({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはコミュニティ広場画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Social/FriendList.tsx
+++ b/src/screens/Social/FriendList.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function FriendList({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはフレンドリスト画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Social/MatchRanking.tsx
+++ b/src/screens/Social/MatchRanking.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function MatchRanking({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは相性ランキング画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Social/ShareCard.tsx
+++ b/src/screens/Social/ShareCard.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function ShareCard({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはシェアカード生成画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Tarot/TarotCardMean.tsx
+++ b/src/screens/Tarot/TarotCardMean.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function TarotCardMean({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはカード意味画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Tarot/TarotDraw.tsx
+++ b/src/screens/Tarot/TarotDraw.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function TarotDraw({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これはカードを引く画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Tarot/TarotResult.tsx
+++ b/src/screens/Tarot/TarotResult.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function TarotResult({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは結果ページ画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});

--- a/src/screens/Tarot/TarotSelect.tsx
+++ b/src/screens/Tarot/TarotSelect.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+export default function TarotSelect({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+      <Text style={styles.title}>これは占いテーマ選択画面です</Text>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+        <Text style={styles.buttonText}>下一页へ</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>
+        <Text style={styles.buttonText}>戻る</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 20, marginBottom: 20, color: '#333' },
+  button: { backgroundColor: 'white', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 20, marginVertical: 5 },
+  buttonText: { color: '#FF69B4', fontSize: 16 },
+});


### PR DESCRIPTION
## Summary
- add placeholder page skeletons across modules
- implement new navigation with Stack and Tab navigators
- include generated snapshot for tests

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6854353d8e648320af781c775292a17d