### PR TITLE
Fix nested navigation references

### DIFF
--- a/src/screens/Auth/PrivacyPolicyScreen.tsx
+++ b/src/screens/Auth/PrivacyPolicyScreen.tsx
@@ -6,7 +6,7 @@ export default function PrivacyPolicyScreen({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはプライバシーポリシー画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Auth/SMSVerifyScreen.tsx
+++ b/src/screens/Auth/SMSVerifyScreen.tsx
@@ -6,7 +6,7 @@ export default function SMSVerifyScreen({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは認証コード入力画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Auth/SplashScreen.tsx
+++ b/src/screens/Auth/SplashScreen.tsx
@@ -6,7 +6,7 @@ export default function SplashScreen({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはスプラッシュ画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Bazi/BaziBasicAnalysis.tsx
+++ b/src/screens/Bazi/BaziBasicAnalysis.tsx
@@ -6,7 +6,7 @@ export default function BaziBasicAnalysis({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは基本分析画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Bazi/BaziDetailAnalysis.tsx
+++ b/src/screens/Bazi/BaziDetailAnalysis.tsx
@@ -6,7 +6,7 @@ export default function BaziDetailAnalysis({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは性格運勢画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Bazi/BaziInput.tsx
+++ b/src/screens/Bazi/BaziInput.tsx
@@ -6,7 +6,7 @@ export default function BaziInput({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは四柱八字入力画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Bazi/BaziLuckFlow.tsx
+++ b/src/screens/Bazi/BaziLuckFlow.tsx
@@ -6,7 +6,7 @@ export default function BaziLuckFlow({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは大運流年画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/ChatAI/ChatHistory.tsx
+++ b/src/screens/ChatAI/ChatHistory.tsx
@@ -6,7 +6,7 @@ export default function ChatHistory({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはチャット履歴画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/ChatAI/ChatList.tsx
+++ b/src/screens/ChatAI/ChatList.tsx
@@ -6,7 +6,7 @@ export default function ChatList({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはAIキャラ選択画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/ChatAI/ChatScreen.tsx
+++ b/src/screens/ChatAI/ChatScreen.tsx
@@ -6,7 +6,7 @@ export default function ChatScreen({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはチャット画面画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/ChatAI/ChatTopicSuggest.tsx
+++ b/src/screens/ChatAI/ChatTopicSuggest.tsx
@@ -6,7 +6,7 @@ export default function ChatTopicSuggest({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは話題テンプレート画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Commerce/InviteFriend.tsx
+++ b/src/screens/Commerce/InviteFriend.tsx
@@ -6,7 +6,7 @@ export default function InviteFriend({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは招待特典画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Commerce/PaymentScreen.tsx
+++ b/src/screens/Commerce/PaymentScreen.tsx
@@ -6,7 +6,7 @@ export default function PaymentScreen({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはお支払い画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Commerce/PointShop.tsx
+++ b/src/screens/Commerce/PointShop.tsx
@@ -6,7 +6,7 @@ export default function PointShop({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはポイントショップ画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Commerce/PurchaseHistory.tsx
+++ b/src/screens/Commerce/PurchaseHistory.tsx
@@ -6,7 +6,7 @@ export default function PurchaseHistory({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは購入履歴画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Commerce/SubscribePlan.tsx
+++ b/src/screens/Commerce/SubscribePlan.tsx
@@ -6,7 +6,7 @@ export default function SubscribePlan({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはプラン選択画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Commerce/VIPCenter.tsx
+++ b/src/screens/Commerce/VIPCenter.tsx
@@ -6,7 +6,7 @@ export default function VIPCenter({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはVIPセンター画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Home/DivinationScreen.tsx
+++ b/src/screens/Home/DivinationScreen.tsx
@@ -6,7 +6,7 @@ export default function DivinationScreen({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは占い機能一覧画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Home/MyPageScreen.tsx
+++ b/src/screens/Home/MyPageScreen.tsx
@@ -6,7 +6,7 @@ export default function MyPageScreen({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはマイページ画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Horoscope/HoroscopeDetail.tsx
+++ b/src/screens/Horoscope/HoroscopeDetail.tsx
@@ -6,7 +6,7 @@ export default function HoroscopeDetail({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは星座詳細ページ画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Horoscope/HoroscopeHome.tsx
+++ b/src/screens/Horoscope/HoroscopeHome.tsx
@@ -6,7 +6,7 @@ export default function HoroscopeHome({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは星座占いトップ画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Horoscope/HoroscopeResult.tsx
+++ b/src/screens/Horoscope/HoroscopeResult.tsx
@@ -6,7 +6,7 @@ export default function HoroscopeResult({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは星座運勢結果画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Match/MatchCalculation.tsx
+++ b/src/screens/Match/MatchCalculation.tsx
@@ -6,7 +6,7 @@ export default function MatchCalculation({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは計算画面画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Match/MatchDetail.tsx
+++ b/src/screens/Match/MatchDetail.tsx
@@ -6,7 +6,7 @@ export default function MatchDetail({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは詳細分析画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Match/MatchPartnerInput.tsx
+++ b/src/screens/Match/MatchPartnerInput.tsx
@@ -6,7 +6,7 @@ export default function MatchPartnerInput({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは相性対象入力画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Match/MatchResult.tsx
+++ b/src/screens/Match/MatchResult.tsx
@@ -6,7 +6,7 @@ export default function MatchResult({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは結果表示画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/NatalChart/NatalChartAnalysis.tsx
+++ b/src/screens/NatalChart/NatalChartAnalysis.tsx
@@ -6,7 +6,7 @@ export default function NatalChartAnalysis({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは解読結果画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/NatalChart/NatalChartElementDetail.tsx
+++ b/src/screens/NatalChart/NatalChartElementDetail.tsx
@@ -6,7 +6,7 @@ export default function NatalChartElementDetail({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは要素詳細画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/NatalChart/NatalChartGraph.tsx
+++ b/src/screens/NatalChart/NatalChartGraph.tsx
@@ -6,7 +6,7 @@ export default function NatalChartGraph({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは星図表示画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/NatalChart/NatalChartInput.tsx
+++ b/src/screens/NatalChart/NatalChartInput.tsx
@@ -6,7 +6,7 @@ export default function NatalChartInput({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはホロスコープ生成画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Operation/Announcements.tsx
+++ b/src/screens/Operation/Announcements.tsx
@@ -6,7 +6,7 @@ export default function Announcements({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはお知らせ画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Operation/DailyCheckIn.tsx
+++ b/src/screens/Operation/DailyCheckIn.tsx
@@ -6,7 +6,7 @@ export default function DailyCheckIn({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはデイリー報酬画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Operation/EventCenter.tsx
+++ b/src/screens/Operation/EventCenter.tsx
@@ -6,7 +6,7 @@ export default function EventCenter({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはイベント一覧画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Operation/OnboardingGuide.tsx
+++ b/src/screens/Operation/OnboardingGuide.tsx
@@ -6,7 +6,7 @@ export default function OnboardingGuide({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは初心者ガイド画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Operation/SeasonalTheme.tsx
+++ b/src/screens/Operation/SeasonalTheme.tsx
@@ -6,7 +6,7 @@ export default function SeasonalTheme({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは季節イベント占い画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Operation/VersionUpdate.tsx
+++ b/src/screens/Operation/VersionUpdate.tsx
@@ -6,7 +6,7 @@ export default function VersionUpdate({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはバージョン情報画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Profile/AboutUs.tsx
+++ b/src/screens/Profile/AboutUs.tsx
@@ -6,7 +6,7 @@ export default function AboutUs({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはアプリ紹介画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Profile/Favorites.tsx
+++ b/src/screens/Profile/Favorites.tsx
@@ -6,7 +6,7 @@ export default function Favorites({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはお気に入り画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Profile/Feedback.tsx
+++ b/src/screens/Profile/Feedback.tsx
@@ -6,7 +6,7 @@ export default function Feedback({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはフィードバック画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Profile/HelpCenter.tsx
+++ b/src/screens/Profile/HelpCenter.tsx
@@ -6,7 +6,7 @@ export default function HelpCenter({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはヘルプセンター画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Profile/MyReports.tsx
+++ b/src/screens/Profile/MyReports.tsx
@@ -6,7 +6,7 @@ export default function MyReports({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは占い履歴画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Profile/NotificationSettings.tsx
+++ b/src/screens/Profile/NotificationSettings.tsx
@@ -6,7 +6,7 @@ export default function NotificationSettings({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは通知設定画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Profile/Settings.tsx
+++ b/src/screens/Profile/Settings.tsx
@@ -6,7 +6,7 @@ export default function Settings({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはアプリ設定画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Profile/UserProfile.tsx
+++ b/src/screens/Profile/UserProfile.tsx
@@ -6,7 +6,7 @@ export default function UserProfile({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはプロフィール編集画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Social/Community.tsx
+++ b/src/screens/Social/Community.tsx
@@ -6,7 +6,7 @@ export default function Community({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはコミュニティ広場画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Social/FriendList.tsx
+++ b/src/screens/Social/FriendList.tsx
@@ -6,7 +6,7 @@ export default function FriendList({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはフレンドリスト画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Social/MatchRanking.tsx
+++ b/src/screens/Social/MatchRanking.tsx
@@ -6,7 +6,7 @@ export default function MatchRanking({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは相性ランキング画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Social/ShareCard.tsx
+++ b/src/screens/Social/ShareCard.tsx
@@ -6,7 +6,7 @@ export default function ShareCard({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはシェアカード生成画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Tarot/TarotCardMean.tsx
+++ b/src/screens/Tarot/TarotCardMean.tsx
@@ -6,7 +6,7 @@ export default function TarotCardMean({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはカード意味画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Tarot/TarotDraw.tsx
+++ b/src/screens/Tarot/TarotDraw.tsx
@@ -6,7 +6,7 @@ export default function TarotDraw({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これはカードを引く画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Tarot/TarotResult.tsx
+++ b/src/screens/Tarot/TarotResult.tsx
@@ -6,7 +6,7 @@ export default function TarotResult({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは結果ページ画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/Tarot/TarotSelect.tsx
+++ b/src/screens/Tarot/TarotSelect.tsx
@@ -6,7 +6,7 @@ export default function TarotSelect({ navigation }: any) {
   return (
     <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
       <Text style={styles.title}>これは占いテーマ選択画面です</Text>
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
+      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>
       </TouchableOpacity>
       <TouchableOpacity style={styles.button} onPress={() => navigation.goBack()}>

--- a/src/screens/UserInputScreen.tsx
+++ b/src/screens/UserInputScreen.tsx
@@ -92,7 +92,10 @@ export default function UserInputScreen() {
       };
       
       console.log('Form data:', userInfo);
-      (navigation as any).navigate('Home', { userInfo });
+      (navigation as any).navigate('HomeTabs', {
+        screen: 'HomeTab',
+        params: { userInfo },
+      });
     }
   };
 


### PR DESCRIPTION
## Summary
- fix navigation from forms and placeholder screens to nested tab navigator
- navigate to `HomeTabs` instead of nonexistent top-level `Home`
- pass user info params through nested navigation in `UserInputScreen`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854d5004c1c8320b2ec563813fa833c