### PR TITLE
Fix screen paths and unify placeholder styles

### DIFF
--- a/src/screens/Auth/PrivacyPolicyScreen.tsx
+++ b/src/screens/Auth/PrivacyPolicyScreen.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function PrivacyPolicyScreen({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはプライバシーポリシー画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Auth/SMSVerifyScreen.tsx
+++ b/src/screens/Auth/SMSVerifyScreen.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function SMSVerifyScreen({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは認証コード入力画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Auth/SplashScreen.tsx
+++ b/src/screens/Auth/SplashScreen.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function SplashScreen({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはスプラッシュ画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Auth/UserInputScreen.tsx
+++ b/src/screens/Auth/UserInputScreen.tsx
@@ -14,7 +14,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import DateTimePicker from '@react-native-community/datetimepicker';
-import { addressData } from '../assets/addressData';
+import { addressData } from '../../assets/addressData';
 
 const { width, height } = Dimensions.get('window');
 
@@ -107,7 +107,7 @@ export default function UserInputScreen() {
       
       {/* 渐变背景 */}
       <LinearGradient
-        colors={['#a8edea', '#fed6e3']}
+        colors={['#667eea', '#764ba2']}
         style={styles.backgroundGradient}
         start={{ x: 0, y: 0 }}
         end={{ x: 1, y: 1 }}

--- a/src/screens/Chat/ChatHistory.tsx
+++ b/src/screens/Chat/ChatHistory.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function ChatHistory({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはチャット履歴画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Chat/ChatList.tsx
+++ b/src/screens/Chat/ChatList.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function ChatList({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはAIキャラ選択画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Chat/ChatScreen.tsx
+++ b/src/screens/Chat/ChatScreen.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function ChatScreen({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはチャット画面画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Chat/ChatTopicSuggest.tsx
+++ b/src/screens/Chat/ChatTopicSuggest.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function ChatTopicSuggest({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは話題テンプレート画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Commerce/InviteFriend.tsx
+++ b/src/screens/Commerce/InviteFriend.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function InviteFriend({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは招待特典画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Commerce/PaymentScreen.tsx
+++ b/src/screens/Commerce/PaymentScreen.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function PaymentScreen({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはお支払い画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Commerce/PointShop.tsx
+++ b/src/screens/Commerce/PointShop.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function PointShop({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはポイントショップ画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Commerce/PurchaseHistory.tsx
+++ b/src/screens/Commerce/PurchaseHistory.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function PurchaseHistory({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは購入履歴画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Commerce/SubscribePlan.tsx
+++ b/src/screens/Commerce/SubscribePlan.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function SubscribePlan({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはプラン選択画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Commerce/VIPCenter.tsx
+++ b/src/screens/Commerce/VIPCenter.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function VIPCenter({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはVIPセンター画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/Bazi/BaziBasicAnalysis.tsx
+++ b/src/screens/Divination/Bazi/BaziBasicAnalysis.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function BaziBasicAnalysis({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは基本分析画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/Bazi/BaziDetailAnalysis.tsx
+++ b/src/screens/Divination/Bazi/BaziDetailAnalysis.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function BaziDetailAnalysis({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは性格運勢画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/Bazi/BaziInput.tsx
+++ b/src/screens/Divination/Bazi/BaziInput.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function BaziInput({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは四柱八字入力画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/Bazi/BaziLuckFlow.tsx
+++ b/src/screens/Divination/Bazi/BaziLuckFlow.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function BaziLuckFlow({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは大運流年画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/Horoscope/HoroscopeDetail.tsx
+++ b/src/screens/Divination/Horoscope/HoroscopeDetail.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function HoroscopeDetail({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは星座詳細ページ画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/Horoscope/HoroscopeHome.tsx
+++ b/src/screens/Divination/Horoscope/HoroscopeHome.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function HoroscopeHome({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは星座占いトップ画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/Horoscope/HoroscopeResult.tsx
+++ b/src/screens/Divination/Horoscope/HoroscopeResult.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function HoroscopeResult({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは星座運勢結果画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/Match/MatchCalculation.tsx
+++ b/src/screens/Divination/Match/MatchCalculation.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function MatchCalculation({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは計算画面画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/Match/MatchDetail.tsx
+++ b/src/screens/Divination/Match/MatchDetail.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function MatchDetail({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは詳細分析画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/Match/MatchPartnerInput.tsx
+++ b/src/screens/Divination/Match/MatchPartnerInput.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function MatchPartnerInput({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは相性対象入力画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/Match/MatchResult.tsx
+++ b/src/screens/Divination/Match/MatchResult.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function MatchResult({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは結果表示画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/NatalChart/NatalChartAnalysis.tsx
+++ b/src/screens/Divination/NatalChart/NatalChartAnalysis.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function NatalChartAnalysis({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは解読結果画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/NatalChart/NatalChartElementDetail.tsx
+++ b/src/screens/Divination/NatalChart/NatalChartElementDetail.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function NatalChartElementDetail({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは要素詳細画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/NatalChart/NatalChartGraph.tsx
+++ b/src/screens/Divination/NatalChart/NatalChartGraph.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function NatalChartGraph({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは星図表示画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/NatalChart/NatalChartInput.tsx
+++ b/src/screens/Divination/NatalChart/NatalChartInput.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function NatalChartInput({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはホロスコープ生成画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/Tarot/TarotCardMean.tsx
+++ b/src/screens/Divination/Tarot/TarotCardMean.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function TarotCardMean({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはカード意味画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/Tarot/TarotDraw.tsx
+++ b/src/screens/Divination/Tarot/TarotDraw.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function TarotDraw({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはカードを引く画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/Tarot/TarotResult.tsx
+++ b/src/screens/Divination/Tarot/TarotResult.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function TarotResult({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは結果ページ画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Divination/Tarot/TarotSelect.tsx
+++ b/src/screens/Divination/Tarot/TarotSelect.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function TarotSelect({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは占いテーマ選択画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Main/MyPageScreen.tsx
+++ b/src/screens/Main/MyPageScreen.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function MyPageScreen({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはマイページ画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Operation/Announcements.tsx
+++ b/src/screens/Operation/Announcements.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function Announcements({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはお知らせ画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Operation/DailyCheckIn.tsx
+++ b/src/screens/Operation/DailyCheckIn.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function DailyCheckIn({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはデイリー報酬画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Operation/EventCenter.tsx
+++ b/src/screens/Operation/EventCenter.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function EventCenter({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはイベント一覧画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Operation/OnboardingGuide.tsx
+++ b/src/screens/Operation/OnboardingGuide.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function OnboardingGuide({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは初心者ガイド画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Operation/SeasonalTheme.tsx
+++ b/src/screens/Operation/SeasonalTheme.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function SeasonalTheme({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは季節イベント占い画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Operation/VersionUpdate.tsx
+++ b/src/screens/Operation/VersionUpdate.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function VersionUpdate({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはバージョン情報画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Profile/AboutUs.tsx
+++ b/src/screens/Profile/AboutUs.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function AboutUs({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはアプリ紹介画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Profile/Favorites.tsx
+++ b/src/screens/Profile/Favorites.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function Favorites({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはお気に入り画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Profile/Feedback.tsx
+++ b/src/screens/Profile/Feedback.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function Feedback({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはフィードバック画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Profile/HelpCenter.tsx
+++ b/src/screens/Profile/HelpCenter.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function HelpCenter({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはヘルプセンター画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Profile/MyReports.tsx
+++ b/src/screens/Profile/MyReports.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function MyReports({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは占い履歴画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Profile/NotificationSettings.tsx
+++ b/src/screens/Profile/NotificationSettings.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function NotificationSettings({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは通知設定画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Profile/Settings.tsx
+++ b/src/screens/Profile/Settings.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function Settings({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはアプリ設定画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Profile/UserProfile.tsx
+++ b/src/screens/Profile/UserProfile.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function UserProfile({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはプロフィール編集画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Social/Community.tsx
+++ b/src/screens/Social/Community.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function Community({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはコミュニティ広場画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Social/FriendList.tsx
+++ b/src/screens/Social/FriendList.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function FriendList({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはフレンドリスト画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Social/MatchRanking.tsx
+++ b/src/screens/Social/MatchRanking.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function MatchRanking({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これは相性ランキング画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>

--- a/src/screens/Social/ShareCard.tsx
+++ b/src/screens/Social/ShareCard.tsx
@@ -4,7 +4,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 
 export default function ShareCard({ navigation }: any) {
   return (
-    <LinearGradient colors={['#a8edea', '#fed6e3']} style={styles.container}>
+    <LinearGradient colors={['#667eea', '#764ba2']} style={styles.container}>
       <Text style={styles.title}>これはシェアカード生成画面です</Text>
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('HomeTabs')}>
         <Text style={styles.buttonText}>下一页へ</Text>


### PR DESCRIPTION
## Summary
- point screens to correct addressData path
- apply gradient theme to placeholder pages
- keep simple navigation on each screen

## Testing
- `npm test --silent -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68551cf4fa688320847f091d1582e6b0